### PR TITLE
Add Chess960 support

### DIFF
--- a/perftree-cli/src/bin/perftree.rs
+++ b/perftree-cli/src/bin/perftree.rs
@@ -102,6 +102,12 @@ fn main() -> io::Result<()> {
             "exit" | "quit" => {
                 break;
             }
+            "chess960" => {
+                state.set_chess960(true);
+            }
+            "nochess960" => {
+                state.set_chess960(false);
+            }
             other => {
                 eprintln!("unknown command {:?}", other);
             }

--- a/perftree-cli/src/bin/perftree.rs
+++ b/perftree-cli/src/bin/perftree.rs
@@ -102,11 +102,19 @@ fn main() -> io::Result<()> {
             "exit" | "quit" => {
                 break;
             }
-            "chess960" => {
-                state.set_chess960(true);
-            }
-            "nochess960" => {
-                state.set_chess960(false);
+            "chess960" | "frc" => {
+                if let Some(chess960) = words.next() {
+                    match chess960.parse() {
+                        Ok(chess960) => {
+                            state.set_chess960(chess960)?;
+                        }
+                        Err(e) => {
+                            eprintln!("cannot parse given bool: {}", e);
+                        }
+                    }
+                } else {
+                    eprintln!("missing argument, expected true or false");
+                }
             }
             other => {
                 eprintln!("unknown command {:?}", other);

--- a/perftree/src/lib.rs
+++ b/perftree/src/lib.rs
@@ -263,7 +263,7 @@ impl Engine for Stockfish {
         // Enable/disable Chess960
         write!(
             self.out,
-            "setoption name UCI_Chess960 value {}",
+            "setoption name UCI_Chess960 value {}\n",
             self.chess960
         )?;
         // send command to stockfish


### PR DESCRIPTION
Closes #10
This adds the `chess960` and `frc` commands as well as a function on the `State` struct to enable/disable the `UCI_Chess960` option on stockfish. 
perftree now sends `setoption name UCI_Chess960 value {bool}` to stockfish when `chess960 [bool]` or `frc [bool]` is used.
