### PR TITLE
Stockfish 16 support: Ignore stockfish info messages

### DIFF
--- a/perftree/src/lib.rs
+++ b/perftree/src/lib.rs
@@ -267,6 +267,11 @@ impl Engine for Stockfish {
             if buf.trim().is_empty() {
                 break;
             }
+
+            if buf.starts_with("info") {
+                continue;
+            }
+
             let mut parts = buf.trim().split(": ");
             let move_ = parts
                 .next()


### PR DESCRIPTION
The perftree CLI is failing with Stockfish 16 because it doesn't handle the "info" debugging messages it is receiving. This PR fixes this by ignoring all info messages from stockfish.

This should resolve [issue ](https://github.com/agausmann/perftree/issues/13).