### PR TITLE
Add support for extra script arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ g1f3 440
 ### Running perftree
 
 Run `perftree` from the commandline, and pass the path to your perft executable
-as the first argument:
+as the first argument. You can also provide extra arguments that will be passed
+to your script before the depth, fen, and moves arguments:
 
 ```bash
-perftree ./your-script.sh
+perftree ./your-script.sh [extra arguments]
 ```
 
 `perftree` understands the following commands:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ g1f3 440
 
 #### Windows Scripting
 
-On Windows, using a Batch file for your user script is suggested for the easiest setup.
+On Windows, using a batch file for your user script is suggested for the easiest setup.
 
 ### Running perftree
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ g1f3 440
 8902
 ```
 
+#### Windows Scripting
+
+On Windows, using a Batch file for your user script is suggested for the easiest setup.
+
 ### Running perftree
 
 Run `perftree` from the commandline, and pass the path to your perft executable

--- a/perftree-cli/src/bin/perftree.rs
+++ b/perftree-cli/src/bin/perftree.rs
@@ -42,7 +42,10 @@ fn main() -> anyhow::Result<()> {
     let mut prompt = Prompt::new(input.lock());
     let mut output = StandardStream::stdout(ColorChoice::Auto);
 
-    let mut state = State::new(env::args().nth(1).unwrap_or_else(|| usage()), env::args().skip(2).collect())?;
+    let mut state = State::new(
+        env::args().nth(1).unwrap_or_else(|| usage()),
+        env::args().skip(2).collect(),
+    )?;
 
     while let Some(line) = prompt.prompt("> ")? {
         let mut words = line.split_whitespace();

--- a/perftree-cli/src/bin/perftree.rs
+++ b/perftree-cli/src/bin/perftree.rs
@@ -42,7 +42,7 @@ fn main() -> anyhow::Result<()> {
     let mut prompt = Prompt::new(input.lock());
     let mut output = StandardStream::stdout(ColorChoice::Auto);
 
-    let mut state = State::new(env::args().nth(1).unwrap_or_else(|| usage()))?;
+    let mut state = State::new(env::args().nth(1).unwrap_or_else(|| usage()), env::args().skip(2).collect())?;
 
     while let Some(line) = prompt.prompt("> ")? {
         let mut words = line.split_whitespace();

--- a/perftree/src/lib.rs
+++ b/perftree/src/lib.rs
@@ -15,13 +15,13 @@ pub struct State {
 }
 
 impl State {
-    pub fn new<S>(cmd: S) -> anyhow::Result<State>
+    pub fn new<S>(cmd: S, args: Vec<String>) -> anyhow::Result<State>
     where
         S: Into<String>,
     {
         Ok(State {
             stockfish: Stockfish::new().context("failed to initialize stockfish")?,
-            script: Script::new(cmd),
+            script: Script::new(cmd, args),
             fen: INITIAL_FEN.to_string(),
             moves: Vec::new(),
             depth: 1,
@@ -146,20 +146,22 @@ impl Perft {
 
 pub struct Script {
     cmd: String,
+    args: Vec<String>,
 }
 
 impl Script {
-    pub fn new<S>(cmd: S) -> Script
+    pub fn new<S>(cmd: S, args: Vec<String>) -> Script
     where
         S: Into<String>,
     {
-        Script { cmd: cmd.into() }
+        Script { cmd: cmd.into(), args }
     }
 }
 
 impl Engine for Script {
     fn perft(&mut self, fen: &str, moves: &[String], depth: usize) -> anyhow::Result<Perft> {
         let mut command = Command::new(&self.cmd);
+        command.args(&self.args);
         command.arg(depth.to_string());
         command.arg(fen);
         if !moves.is_empty() {

--- a/perftree/src/lib.rs
+++ b/perftree/src/lib.rs
@@ -154,7 +154,10 @@ impl Script {
     where
         S: Into<String>,
     {
-        Script { cmd: cmd.into(), args }
+        Script {
+            cmd: cmd.into(),
+            args,
+        }
     }
 }
 


### PR DESCRIPTION
This PR allows passing extra arguments to the user script. For example, calling `perftree ./program.exe a b` will result in `diff` making this call: `./program.exe a b <depth> <fen> <moves>`.

With this change I was able to run my program through a bash script on Windows with git bash `perftree "C:\Program Files\Git\bin\bash.exe" ./fox-perftree.sh` so I think this would close #7.

I have setup my program to run perft when called like so: `./program.exe perft <depth> <fen> <moves>`. I tried to setup a script to call my program like this, but was not able to get it working on Windows:
1. If I had perftree try to call the script directly `perftree .\script.ps1` then I got this error: `cannot compute diff: failed to execute user script: %1 is not a valid Win32 application. (os error 193)`
2. If I had perftree call the script interpreter (bash or powershell) with the script, it ignored it and did not pass the script name to the interpreter. Calling `perftree powershell .\script.ps1` means it calls `powershell <depth> <fen> <moves>`.
3. If I used quotes to include the argument in the script command `perftree "powershell .\script.ps1"` then I got this error `cannot compute diff: failed to execute user script: The system cannot find the path specified. (os error 3)`

I was not able to run my program though a powershell script because it interpreted each space in the fen as a separate argument. This should be fixable by adding parsing logic in my script or my program, but I don't care to put in the effort for that. This is consistent with the `Command.arg()` documentation https://doc.rust-lang.org/stable/std/process/index.html#windows-argument-splitting.

For completeness just before posting this I tested using Windows Command Line Batch script. That just worked, this change is not necessary to use that. Oh well.